### PR TITLE
feat: faster end fights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff
 .idea/
+.vs/
 baritone/
 
 *.iml

--- a/src/main/java/adris/altoclef/Playground.java
+++ b/src/main/java/adris/altoclef/Playground.java
@@ -10,6 +10,7 @@ import adris.altoclef.tasks.construction.compound.ConstructNetherPortalObsidianT
 import adris.altoclef.tasks.container.SmeltInFurnaceTask;
 import adris.altoclef.tasks.container.StoreInAnyContainerTask;
 import adris.altoclef.tasks.entity.KillEntityTask;
+import adris.altoclef.tasks.entity.ShootArrowSimpleProjectileTask;
 import adris.altoclef.tasks.examples.ExampleTask2;
 import adris.altoclef.tasks.misc.EquipArmorTask;
 import adris.altoclef.tasks.misc.PlaceBedAndSetSpawnTask;
@@ -31,7 +32,9 @@ import adris.altoclef.util.*;
 import adris.altoclef.util.helpers.WorldHelper;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.GhastEntity;
 import net.minecraft.entity.mob.ZombieEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
@@ -43,6 +46,7 @@ import net.minecraft.world.chunk.EmptyChunk;
 
 import java.io.*;
 import java.util.List;
+import java.util.Optional;
 import java.util.Scanner;
 
 /**
@@ -334,6 +338,18 @@ public class Playground {
                         new ItemTarget("netherite_chestplate", 1),
                         new ItemTarget("netherite_leggings", 1),
                         new ItemTarget("netherite_boots", 1)));
+                break;
+            case "arrow":
+
+                List<GhastEntity> ghasts = mod.getEntityTracker().getTrackedEntities(GhastEntity.class);
+
+                if (ghasts.size() == 0) {
+                    Debug.logWarning("No ghasts found.");
+                    break;
+                }
+
+                GhastEntity ghast = ghasts.get(0);
+                mod.runUserTask(new ShootArrowSimpleProjectileTask(ghast));
                 break;
             case "whisper": {
                 File check = new File("whisper.txt");

--- a/src/main/java/adris/altoclef/TaskCatalogue.java
+++ b/src/main/java/adris/altoclef/TaskCatalogue.java
@@ -71,7 +71,7 @@ public class TaskCatalogue {
             mine("diamond", MiningRequirement.IRON, new Block[]{Blocks.DIAMOND_ORE, Blocks.DEEPSLATE_DIAMOND_ORE}, Items.DIAMOND);
             mine("emerald", MiningRequirement.IRON, new Block[]{Blocks.EMERALD_ORE, Blocks.DEEPSLATE_EMERALD_ORE}, Items.EMERALD);
             mine("redstone", MiningRequirement.IRON, new Block[]{Blocks.REDSTONE_ORE, Blocks.DEEPSLATE_REDSTONE_ORE}, Items.REDSTONE);
-            mine("lapis_lazuli", MiningRequirement.IRON, new Block[]{Blocks.LAPIS_ORE, Blocks.DEEPSLATE_LAPIS_ORE}, Items.LAPIS_LAZULI);
+            mine("lapis_lazuli", MiningRequirement.STONE, new Block[]{Blocks.LAPIS_ORE, Blocks.DEEPSLATE_LAPIS_ORE}, Items.LAPIS_LAZULI);
             alias("lapis", "lapis_lazuli");
             mine("amethyst_shard", MiningRequirement.WOOD, Blocks.AMETHYST_CLUSTER, Items.AMETHYST_SHARD);
             mine("pointed_dripstone", MiningRequirement.WOOD, Blocks.POINTED_DRIPSTONE, Items.POINTED_DRIPSTONE);

--- a/src/main/java/adris/altoclef/chains/DeathMenuChain.java
+++ b/src/main/java/adris/altoclef/chains/DeathMenuChain.java
@@ -89,12 +89,10 @@ public class DeathMenuChain extends TaskChain {
                         String command = i.replace("{deathmessage}", deathMessage);
                         String prefix = mod.getModSettings().getCommandPrefix();
                         while (MinecraftClient.getInstance().player.isAlive()) ;
-                        if (command != "") {
+                        if (!command.isEmpty()) {
                             if (command.startsWith(prefix)) {
                                 AltoClef.getCommandExecutor().execute(command, () -> {
-                                }, e -> {
-                                    e.printStackTrace();
-                                });
+                                }, Throwable::printStackTrace);
                             } else if (command.startsWith("/")) {
                                 MinecraftClient.getInstance().player.networkHandler.sendChatCommand(command.substring(1));
                             } else {

--- a/src/main/java/adris/altoclef/chains/MobDefenseChain.java
+++ b/src/main/java/adris/altoclef/chains/MobDefenseChain.java
@@ -26,8 +26,7 @@ import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.*;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.projectile.DragonFireballEntity;
-import net.minecraft.entity.projectile.FireballEntity;
+import net.minecraft.entity.projectile.*;
 import net.minecraft.entity.projectile.thrown.PotionEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -38,6 +37,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 
 import java.util.*;
+
+import static java.lang.Math.abs;
 
 public class MobDefenseChain extends SingleTaskChain {
     private static final double DANGER_KEEP_DISTANCE = 30;
@@ -516,6 +517,17 @@ public class MobDefenseChain extends SingleTaskChain {
                             // Ignore dragon fireballs
                             return false;
                         }
+                        if (projectile.projectileType == ArrowEntity.class || projectile.projectileType == SpectralArrowEntity.class || projectile.projectileType == SmallFireballEntity.class) {
+                            // check if the velocity of the projectile is going away from us
+                            // oh no fancy math
+                            Vec3d velocity = projectile.velocity;
+                            Vec3d delta = mod.getPlayer().getPos().subtract(projectile.position);
+                            double epsilon = 0.25;
+                            if (abs(velocity.dotProduct(delta)) <= epsilon) {
+                                // Arrow is going away from us, ignore it.
+                                continue;
+                            }
+                        }
 
                         Vec3d expectedHit = ProjectileHelper.calculateArrowClosestApproach(projectile, mod.getPlayer());
 
@@ -524,7 +536,7 @@ public class MobDefenseChain extends SingleTaskChain {
                         //Debug.logMessage("EXPECTED HIT OFFSET: " + delta + " ( " + projectile.gravity + ")");
 
                         double horizontalDistanceSq = delta.x * delta.x + delta.z * delta.z;
-                        double verticalDistance = Math.abs(delta.y);
+                        double verticalDistance = abs(delta.y);
                         if (horizontalDistanceSq < ARROW_KEEP_DISTANCE_HORIZONTAL * ARROW_KEEP_DISTANCE_HORIZONTAL && verticalDistance < ARROW_KEEP_DISTANCE_VERTICAL) {
                             if (_runAwayTask == null && mod.getClientBaritone().getPathingBehavior().isSafeToCancel()) {
                                 mod.getClientBaritone().getPathingBehavior().requestPause();

--- a/src/main/java/adris/altoclef/commands/CoordsCommand.java
+++ b/src/main/java/adris/altoclef/commands/CoordsCommand.java
@@ -7,7 +7,7 @@ import adris.altoclef.util.helpers.WorldHelper;
 
 public class CoordsCommand extends Command {
     public CoordsCommand() {
-        super("coords", "Get bot's current coordinates");
+        super("coords", "Get the bot's current coordinates");
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/CoverWithBlocksCommand.java
+++ b/src/main/java/adris/altoclef/commands/CoverWithBlocksCommand.java
@@ -8,7 +8,7 @@ import adris.altoclef.tasks.construction.CoverWithBlocksTask;
 
 public class CoverWithBlocksCommand extends Command {
     public CoverWithBlocksCommand() {
-        super("coverwithblocks", "Cover nether lava with blocks.");
+        super("coverwithblocks", "Cover nether lava with blocks");
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/CoverWithSandCommand.java
+++ b/src/main/java/adris/altoclef/commands/CoverWithSandCommand.java
@@ -8,7 +8,7 @@ import adris.altoclef.tasks.construction.CoverWithSandTask;
 
 public class CoverWithSandCommand extends Command {
     public CoverWithSandCommand() {
-        super("coverwithsand", "Cover nether lava with sand.");
+        super("coverwithsand", "Cover nether lava with sand");
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/GotoCommand.java
+++ b/src/main/java/adris/altoclef/commands/GotoCommand.java
@@ -21,7 +21,7 @@ public class GotoCommand extends Command {
         // x y z dimension
         // (dimension)
         // (x z dimension)
-        super("goto", "Tell bot to travel to a set of coordinates.",
+        super("goto", "Tell bot to travel to a set of coordinates",
                 new Arg(GotoTarget.class, "[x y z dimension]/[x z dimension]/[y dimension]/[dimension]/[x y z]/[x z]/[y]")
         );
     }

--- a/src/main/java/adris/altoclef/commands/HeroCommand.java
+++ b/src/main/java/adris/altoclef/commands/HeroCommand.java
@@ -8,7 +8,7 @@ import adris.altoclef.tasks.entity.HeroTask;
 
 public class HeroCommand extends Command {
     public HeroCommand() {
-        super("hero", "Kill all hostile mobs.");
+        super("hero", "Kill all hostile mobs");
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/MarvionCommand.java
+++ b/src/main/java/adris/altoclef/commands/MarvionCommand.java
@@ -7,7 +7,7 @@ import adris.altoclef.tasks.speedrun.MarvionBeatMinecraftTask;
 
 public class MarvionCommand extends Command {
     public MarvionCommand() {
-        super("marvion", "Beats the game (Marvion version).");
+        super("marvion", "Beats the game (Marvion version)");
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/SetGammaCommand.java
+++ b/src/main/java/adris/altoclef/commands/SetGammaCommand.java
@@ -11,7 +11,7 @@ import net.minecraft.client.MinecraftClient;
 public class SetGammaCommand extends Command {
 
     public SetGammaCommand() throws CommandException {
-        super("gamma", "sets the brightness to a value", new Arg(Double.class, "gamma", 1.0, 0));
+        super("gamma", "Sets the brightness to a value", new Arg<>(Double.class, "gamma", 1.0, 0));
     }
 
     @Override

--- a/src/main/java/adris/altoclef/tasks/entity/ShootArrowSimpleProjectileTask.java
+++ b/src/main/java/adris/altoclef/tasks/entity/ShootArrowSimpleProjectileTask.java
@@ -1,0 +1,147 @@
+package adris.altoclef.tasks.entity;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.Debug;
+import adris.altoclef.tasks.speedrun.BeatMinecraft2Task;
+import adris.altoclef.tasksystem.Task;
+import adris.altoclef.util.helpers.LookHelper;
+import adris.altoclef.util.time.TimerGame;
+import baritone.api.utils.Rotation;
+import baritone.api.utils.input.Input;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.projectile.ArrowEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ShootArrowSimpleProjectileTask extends Task {
+
+    private final Entity target;
+    private boolean shooting = false;
+    private boolean shot = false;
+
+    private final TimerGame shotTimer = new TimerGame(1);
+
+    public ShootArrowSimpleProjectileTask(Entity target) {
+        this.target = target;
+    }
+
+    @Override
+    protected void onStart(AltoClef mod) {
+        shooting = false;
+    }
+
+    private static Rotation calculateThrowLook(AltoClef mod, Entity target) {
+        // Velocity based on bow charge.
+        float velocity = (mod.getPlayer().getItemUseTime() - mod.getPlayer().getItemUseTimeLeft()) / 20f;
+        velocity = (velocity * velocity + velocity * 2) / 3;
+        if (velocity > 1) velocity = 1;
+
+        // Find the position of the center
+        Vec3d targetCenter = target.getBoundingBox().getCenter();
+
+        double posX = targetCenter.getX();
+        double posY = targetCenter.getY();
+        double posZ = targetCenter.getZ();
+
+        // Adjusting for hitbox heights
+        posY -= 1.9f - target.getHeight();
+
+        double relativeX = posX - mod.getPlayer().getX();
+        double relativeY = posY - mod.getPlayer().getY();
+        double relativeZ = posZ - mod.getPlayer().getZ();
+
+        // Calculate the pitch
+        double hDistance = Math.sqrt(relativeX * relativeX + relativeZ * relativeZ);
+        double hDistanceSq = hDistance * hDistance;
+        final float g = 0.006f;
+        float velocitySq = velocity * velocity;
+        float pitch = (float) -Math.toDegrees(Math.atan((velocitySq - Math.sqrt(velocitySq * velocitySq - g * (g * hDistanceSq + 2 * relativeY * velocitySq))) / (g * hDistance)));
+
+        // Set player rotation
+        if (Float.isNaN(pitch)) {
+            return new Rotation(target.getYaw(), target.getPitch());
+        } else {
+            return new Rotation(Vec3dToYaw(mod, new Vec3d(posX, posY, posZ)), pitch);
+        }
+    }
+
+    private static float Vec3dToYaw(AltoClef mod, Vec3d vec) {
+        return (mod.getPlayer().getYaw() +
+                MathHelper.wrapDegrees((float) Math.toDegrees(Math.atan2(vec.getZ() - mod.getPlayer().getZ(), vec.getX() - mod.getPlayer().getX())) - 90f - mod.getPlayer().getYaw()));
+    }
+
+    @Override
+    protected Task onTick(AltoClef mod) {
+        setDebugState("Shooting projectile");
+        List<Item> requiredArrows = Arrays.asList(Items.ARROW, Items.SPECTRAL_ARROW, Items.TIPPED_ARROW);
+
+        if (!(mod.getItemStorage().hasItem(Items.BOW) &&
+                requiredArrows.stream().anyMatch(mod.getItemStorage()::hasItem))) {
+            Debug.logMessage("Missing items, stopping.");
+            return null;
+        }
+
+        Rotation lookTarget = calculateThrowLook(mod, target);
+        LookHelper.lookAt(mod, lookTarget);
+
+        // check if we are holding a bow
+        boolean charged = mod.getPlayer().getItemUseTime() > 20 && mod.getPlayer().getActiveItem().getItem() == Items.BOW;
+
+        mod.getSlotHandler().forceEquipItem(Items.BOW);
+
+        if (LookHelper.isLookingAt(mod, lookTarget) && !shooting) {
+            mod.getInputControls().hold(Input.CLICK_RIGHT);
+            shooting = true;
+            shotTimer.reset();
+        }
+        if (shooting && charged) {
+            List<ArrowEntity> arrows = mod.getEntityTracker().getTrackedEntities(ArrowEntity.class);
+            // If any of the arrows belong to us and are moving, do not shoot yet
+            // Prevents from shooting multiple arrows to the same target
+            for (ArrowEntity arrow : arrows) {
+                if (arrow.getOwner() == mod.getPlayer()) {
+                    Vec3d velocity = arrow.getVelocity();
+                    Vec3d delta = target.getPos().subtract(arrow.getPos());
+                    boolean isMovingTowardsTarget = velocity.dotProduct(delta) > 0;
+                    if (isMovingTowardsTarget) {
+                        return null;
+                    }
+                }
+            }
+
+            if (BeatMinecraft2Task.getConfig().renderDistanceManipulation && MinecraftClient.getInstance().options.getSimulationDistance().getValue() < 32) {
+                // For farther entities, the arrow may get stuck in the air, so we need to increase the simulation distance
+                MinecraftClient.getInstance().options.getSimulationDistance().setValue(32);
+            }
+            mod.getInputControls().release(Input.CLICK_RIGHT); // Release the arrow
+            shot = true;
+        }
+        return null;
+    }
+
+    @Override
+    protected void onStop(AltoClef mod, Task interruptTask) {
+        mod.getInputControls().release(Input.CLICK_RIGHT);
+    }
+
+    @Override
+    public boolean isFinished(AltoClef mod) {
+        return shot;
+    }
+
+    @Override
+    protected boolean isEqual(Task other) {
+        return false;
+    }
+
+    @Override
+    protected String toDebugString() {
+        return "Shooting arrow at " + target.getType().getTranslationKey();
+    }
+}

--- a/src/main/java/adris/altoclef/tasks/speedrun/WaitForDragonAndPearlTask.java
+++ b/src/main/java/adris/altoclef/tasks/speedrun/WaitForDragonAndPearlTask.java
@@ -4,11 +4,7 @@ import adris.altoclef.AltoClef;
 import adris.altoclef.Debug;
 import adris.altoclef.TaskCatalogue;
 import adris.altoclef.tasks.entity.DoToClosestEntityTask;
-import adris.altoclef.tasks.entity.KillEntitiesTask;
-import adris.altoclef.tasks.movement.GetToXZTask;
-import adris.altoclef.tasks.movement.GetToYTask;
-import adris.altoclef.tasks.movement.RunAwayFromPositionTask;
-import adris.altoclef.tasks.movement.ThrowEnderPearlSimpleProjectileTask;
+import adris.altoclef.tasks.movement.*;
 import adris.altoclef.tasks.resources.GetBuildingMaterialsTask;
 import adris.altoclef.tasksystem.Task;
 import adris.altoclef.util.helpers.LookHelper;
@@ -18,13 +14,11 @@ import net.minecraft.entity.AreaEffectCloudEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.boss.dragon.EnderDragonEntity;
 import net.minecraft.entity.decoration.EndCrystalEntity;
-import net.minecraft.entity.mob.EndermanEntity;
 import net.minecraft.entity.projectile.DragonFireballEntity;
 import net.minecraft.item.Items;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.Optional;
-import java.util.function.Predicate;
 
 // TODO:
 // The 10 Portal pillars form a 43 block radius, but the angle offset/cycle is random.
@@ -43,15 +37,19 @@ public class WaitForDragonAndPearlTask extends Task implements IDragonWaiter {
 
     private static final int CLOSE_ENOUGH_DISTANCE = 15;
 
+    private final int Y_COORDINATE = 75;
+
     private static final double DRAGON_FIREBALL_TOO_CLOSE_RANGE = 40;
-    private static boolean inCenter;
     private final Task _buildingMaterialsTask = new GetBuildingMaterialsTask(HEIGHT + 10);
+    boolean inCenter;
     private Task _heightPillarTask;
     private Task _throwPearlTask;
     private BlockPos _targetToPearl;
     private boolean _dragonIsPerching;
     // To avoid dragons breath
     private Task _pillarUpFurther;
+
+    private boolean _hasPillar = false;
 
     @Override
     public void setExitPortalTop(BlockPos top) {
@@ -73,21 +71,26 @@ public class WaitForDragonAndPearlTask extends Task implements IDragonWaiter {
 
     @Override
     protected Task onTick(AltoClef mod) {
-        Optional<Entity> enderMen = mod.getEntityTracker().getClosestEntity(EndermanEntity.class);
-        if (enderMen.isPresent() && (enderMen.get() instanceof EndermanEntity endermanEntity) &&
-                endermanEntity.isAngry()) {
-            setDebugState("Killing angry endermen");
-            Predicate<Entity> angry = entity -> endermanEntity.isAngry();
-            return new KillEntitiesTask(angry, enderMen.get().getClass());
-        }
         if (_throwPearlTask != null && _throwPearlTask.isActive() && !_throwPearlTask.isFinished(mod)) {
             setDebugState("Throwing pearl!");
             return _throwPearlTask;
         }
 
-        if (_pillarUpFurther != null && _pillarUpFurther.isActive() && !_pillarUpFurther.isFinished(mod)) {
-            setDebugState("PILLAR UP FURTHER to avoid dragon's breath");
-            return _pillarUpFurther;
+        if (_pillarUpFurther != null && _pillarUpFurther.isActive() && !_pillarUpFurther.isFinished(mod) && (mod.getEntityTracker().getClosestEntity(AreaEffectCloudEntity.class).isPresent())) {
+
+            Optional<Entity> cloud = mod.getEntityTracker().getClosestEntity(AreaEffectCloudEntity.class);
+
+            if (cloud.isPresent() && cloud.get().isInRange(mod.getPlayer(), 4)) {
+                setDebugState("PILLAR UP FURTHER to avoid dragon's breath");
+                return _pillarUpFurther;
+            }
+
+            Optional<Entity> fireball = mod.getEntityTracker().getClosestEntity(DragonFireballEntity.class);
+
+            if (isFireballDangerous(mod, fireball)) {
+                setDebugState("PILLAR UP FURTHER to avoid dragon's breath");
+                return _pillarUpFurther;
+            }
         }
 
         if (!mod.getItemStorage().hasItem(Items.ENDER_PEARL) && inCenter) {
@@ -125,15 +128,15 @@ public class WaitForDragonAndPearlTask extends Task implements IDragonWaiter {
                                 if (toDestroy.isInRange(mod.getPlayer(), 7)) {
                                     mod.getControllerExtras().attack(toDestroy);
                                 }
-                                if (mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).isPresent() &&
-                                        !mod.getClientBaritone().getPathingBehavior().isPathing()) {
-                                    LookHelper.lookAt(mod, mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).get().getEyePos());
-                                }
-                                if (mod.getPlayer().getY() < minHeight) {
-                                    setDebugState("Pillaring up!");
+                                if (mod.getPlayer().getBlockPos().getY() < minHeight) {
                                     return _heightPillarTask;
+                                } else {
+                                    if (mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).isPresent() &&
+                                            !mod.getClientBaritone().getPathingBehavior().isPathing()) {
+                                        LookHelper.lookAt(mod, mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).get().getEyePos());
+                                    }
+                                    return null;
                                 }
-                                return null;
                             },
                             EndCrystalEntity.class
                     );
@@ -156,15 +159,15 @@ public class WaitForDragonAndPearlTask extends Task implements IDragonWaiter {
                             if (toDestroy.isInRange(mod.getPlayer(), 7)) {
                                 mod.getControllerExtras().attack(toDestroy);
                             }
-                            if (mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).isPresent() &&
-                                    !mod.getClientBaritone().getPathingBehavior().isPathing()) {
-                                LookHelper.lookAt(mod, mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).get().getEyePos());
-                            }
-                            if (mod.getPlayer().getY() < minHeight) {
-                                setDebugState("Pillaring up!");
+                            if (mod.getPlayer().getBlockPos().getY() < minHeight) {
                                 return _heightPillarTask;
+                            } else {
+                                if (mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).isPresent() &&
+                                        !mod.getClientBaritone().getPathingBehavior().isPathing()) {
+                                    LookHelper.lookAt(mod, mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).get().getEyePos());
+                                }
+                                return null;
                             }
-                            return null;
                         },
                         EndCrystalEntity.class
                 );
@@ -175,19 +178,7 @@ public class WaitForDragonAndPearlTask extends Task implements IDragonWaiter {
             }
             return null;
         }
-        if (WorldHelper.inRangeXZ(mod.getPlayer(), _targetToPearl, XZ_RADIUS)) {
-            if (mod.getEntityTracker().entityFound(entity ->
-                    mod.getPlayer().getPos().isInRange(entity.getPos(), 4), AreaEffectCloudEntity.class)) {
-                if (mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).isPresent() &&
-                        !mod.getClientBaritone().getPathingBehavior().isPathing()) {
-                    LookHelper.lookAt(mod, mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).get().getEyePos());
-                }
-                return null;
-            }
-            setDebugState("Moving away from center...");
-            return new RunAwayFromPositionTask(XZ_RADIUS, _targetToPearl);
-        }
-        if (!WorldHelper.inRangeXZ(mod.getPlayer(), _targetToPearl, XZ_RADIUS_TOO_FAR)) {
+        if (!WorldHelper.inRangeXZ(mod.getPlayer(), _targetToPearl, XZ_RADIUS_TOO_FAR) && mod.getPlayer().getPos().getY() < minHeight && !_hasPillar) {
             if (mod.getEntityTracker().entityFound(entity ->
                     mod.getPlayer().getPos().isInRange(entity.getPos(), 4), AreaEffectCloudEntity.class)) {
                 if (mod.getEntityTracker().getClosestEntity(EnderDragonEntity.class).isPresent() &&
@@ -200,8 +191,21 @@ public class WaitForDragonAndPearlTask extends Task implements IDragonWaiter {
             return new GetToXZTask(0, 0);
         }
         // We're far enough, pillar up!
-        _heightPillarTask = new GetToYTask(minHeight);
+        if (!_hasPillar) {
+            _hasPillar = true;
+        }
+        _heightPillarTask = new GetToBlockTask(new BlockPos(0, minHeight, Y_COORDINATE));
         return _heightPillarTask;
+    }
+
+    private boolean isFireballDangerous(AltoClef mod, Optional<Entity> fireball) {
+        if (!fireball.isPresent())
+            return false;
+
+        boolean fireballTooClose = fireball.get().isInRange(mod.getPlayer(), DRAGON_FIREBALL_TOO_CLOSE_RANGE);
+        boolean fireballInSight = LookHelper.cleanLineOfSight(mod.getPlayer(), fireball.get().getPos(), DRAGON_FIREBALL_TOO_CLOSE_RANGE);
+
+        return fireballTooClose && fireballInSight;
     }
 
     @Override

--- a/src/main/java/adris/altoclef/util/helpers/LookHelper.java
+++ b/src/main/java/adris/altoclef/util/helpers/LookHelper.java
@@ -521,6 +521,24 @@ public interface LookHelper {
      *
      * @param mod      The instance of AltoClef.
      * @param rotation The desired rotation to look at.
+     * @param withBaritone Whether to use Baritone to look.
+     */
+    static void lookAt(AltoClef mod, Rotation rotation, boolean withBaritone) {
+        if (withBaritone) {
+            // Update the target rotation in the LookBehavior
+            mod.getClientBaritone().getLookBehavior().updateTarget(rotation, true);
+        }
+
+        // Set the player's yaw and pitch
+        mod.getPlayer().setYaw(rotation.getYaw());
+        mod.getPlayer().setPitch(rotation.getPitch());
+    }
+
+    /**
+     * Updates the player's look direction and rotation.
+     *
+     * @param mod      The instance of AltoClef.
+     * @param rotation The desired rotation to look at.
      */
     static void lookAt(AltoClef mod, Rotation rotation) {
         // Update the target rotation in the LookBehavior
@@ -536,6 +554,23 @@ public interface LookHelper {
      *
      * @param mod    The AltoClef instance.
      * @param toLook The position to look at.
+     * @param withBaritone Whether to use Baritone to look.
+     * @throws IllegalArgumentException if mod or toLook is null.
+     */
+    static void lookAt(AltoClef mod, Vec3d toLook, boolean withBaritone) {
+        if (mod == null || toLook == null) {
+            throw new IllegalArgumentException("mod and toLook cannot be null");
+        }
+
+        Rotation targetRotation = getLookRotation(mod, toLook);
+        lookAt(mod, targetRotation, withBaritone);
+    }
+
+    /**
+     * Adjusts the player's look direction to the specified target position.
+     *
+     * @param mod    The AltoClef instance.
+     * @param toLook The position to look at.
      * @throws IllegalArgumentException if mod or toLook is null.
      */
     static void lookAt(AltoClef mod, Vec3d toLook) {
@@ -544,7 +579,38 @@ public interface LookHelper {
         }
 
         Rotation targetRotation = getLookRotation(mod, toLook);
-        lookAt(mod, targetRotation);
+        lookAt(mod, targetRotation, true);
+    }
+
+    /**
+     * Adjusts the player's view to look at a specific location from a specific direction.
+     *
+     * @param mod    The AltoClef mod instance.
+     * @param toLook The position to look at.
+     * @param side   The direction to look from.
+     * @param withBaritone Whether to use Baritone to look.
+     */
+    static void lookAt(AltoClef mod, BlockPos toLook, Direction side, boolean withBaritone) {
+        // Calculate the center coordinates of the target location
+        double centerX = toLook.getX() + 0.5;
+        double centerY = toLook.getY() + 0.5;
+        double centerZ = toLook.getZ() + 0.5;
+
+        // Adjust the center coordinates based on the specified side
+        if (side != null) {
+            double offsetX = side.getVector().getX() * 0.5;
+            double offsetY = side.getVector().getY() * 0.5;
+            double offsetZ = side.getVector().getZ() * 0.5;
+            centerX += offsetX;
+            centerY += offsetY;
+            centerZ += offsetZ;
+        }
+
+        // Create a target vector based on the adjusted center coordinates
+        Vec3d target = new Vec3d(centerX, centerY, centerZ);
+
+        // Adjust the player's view to look at the target location
+        lookAt(mod, target, withBaritone);
     }
 
     /**
@@ -574,7 +640,18 @@ public interface LookHelper {
         Vec3d target = new Vec3d(centerX, centerY, centerZ);
 
         // Adjust the player's view to look at the target location
-        lookAt(mod, target);
+        lookAt(mod, target, true);
+    }
+
+    /**
+     * Looks at the specified block position.
+     *
+     * @param mod    The AltoClef instance.
+     * @param toLook The block position to look at.
+     * @param withBaritone Whether to use Baritone to look.
+     */
+    static void lookAt(AltoClef mod, BlockPos toLook, boolean withBaritone) {
+        lookAt(mod, toLook, null, withBaritone);
     }
 
     /**
@@ -584,7 +661,7 @@ public interface LookHelper {
      * @param toLook The block position to look at.
      */
     static void lookAt(AltoClef mod, BlockPos toLook) {
-        lookAt(mod, toLook, null);
+        lookAt(mod, toLook, null, true);
     }
 
     /**


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

### Goals

By moving farther away from the Ender Dragon fountain, we can increase the perch chance [1]. This allows for faster runs [2]. 

The dragon phase to detect perching now also included "perch approach," giving more time for the bot to setup for the one-cycle. Moving towards the fountain at this point in the dragon phase does not affect perch time.

The bot also tries to setup for a North-South perch which is a lot faster in terms of perch time than other perch approaches (East-West and Northeast-Southwest/Northwest-Southeast) [3].

There are also a few miscellaneous fixes that should be quite self-explanatory

## Media

New implementation builds tower farther from center
![unknown](https://github.com/MarvionKirito/altoclef/assets/89910983/ff8b031e-959f-4824-85c0-0b97a47d8947)

Current implementation builds tower near the center
![unknown](https://github.com/MarvionKirito/altoclef/assets/89910983/7d0ef751-7583-47e9-b884-e6d6384a1bbd)

Different perches
![Perches](https://github.com/MarvionKirito/altoclef/assets/89910983/4478a1b3-1a18-42f2-91ec-ec3be049ab65)

[North-south perch shorter for dragon to path to it (youtube.com)](https://youtu.be/u3GN89Dji4E)

### Results

[data sets](https://docs.google.com/spreadsheets/d/18UWNUVfKKIskMPhi1uCOGNFkS6Y6MfAL_BeFDoyzw0A/edit#gid=0)

<img width="1121" alt="image" src="https://github.com/MarvionKirito/altoclef/assets/89910983/194ae977-62ed-4e96-829e-d2a386bd37b4">

<img width="428" alt="image" src="https://github.com/MarvionKirito/altoclef/assets/89910983/c615fc0d-3583-49ac-b681-553c6a1167b0">

In this data set, Data Set 2 (blue) refers to the current implementation and Data Set 1 (green) refers to the refined implementation.

Based on these 30 trials, the mean of Data Set 2 is higher than that of Data Set 1, indicating that, on average, the values in Data Set 2 are larger. The median of Data Set 1 is lower than that of Data Set 2. The median is less affected by extreme values, making it a robust measure of central tendency. The interquartile range (IQR) of Data Set 2 is larger than that of Data Set 1. This indicates that the middle 50% of values in Data Set 2 are more spread out. Both data sets have "outliers," but the values in Data Set 2 (blue) are more extreme, with values like 753 and 1206 seconds.

### Conclusion

The statistical evaluation supports the preference for Data Set 1, characterized by lower means, a more concentrated distribution, and a comparatively reduced impact of extremities.

However, it is important to address that this is only a small sample of all the possible runs and results on a larger scale may vary. A better statistical analysis can also be done with the Anderson-Darling test.

### References

[1]. https://www.desmos.com/calculator/thqgxyppdt
[2]. https://www.youtube.com/watch?v=Gp7Qsab8JNY
[3]. https://www.speedrun.com/mc/forums/nh9si

### Further Notes
This can be better optimized if done with [zero-cycling](https://www.youtube.com/watch?v=iClDGWL0e5s) (currently seems to be not possible consistently because Baritone is too slow).
Another optimization that can be done is to attempt to use a strategy called "half-bow" where you attempt to shoot at end crystals, which also increase the chance for the dragon to perch. This can be implemented fairly easily and I have implemented the "bow" task below.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.